### PR TITLE
fix: pass winnr instead of bufnr when setting window options

### DIFF
--- a/lua/arena/init.lua
+++ b/lua/arena/init.lua
@@ -218,7 +218,7 @@ function M.open()
 
   -- Window options
   for option, value in pairs(config.window.opts) do
-    vim.api.nvim_win_set_option(bufnr, option, value)
+    vim.api.nvim_win_set_option(winnr, option, value)
   end
 
   -- Autocommands


### PR DESCRIPTION
Hello! I noticed a small bug when trying to set options on the window, this PR fixes it 🙂 

Thanks for the plugin, it is exactly what I was looking for 🙏 

