### PR TITLE
add backslash backup for windows file paths

### DIFF
--- a/lua/arena/init.lua
+++ b/lua/arena/init.lua
@@ -192,7 +192,13 @@ end
 --- @param opts table?
 function M.setup(opts)
   opts = opts or {}
-  config = vim.tbl_deep_extend("force", config, opts)
+  for k, v in pairs(opts) do
+    if type(v) == "table" and type(config[k]) == "table" then
+      config[k] = vim.tbl_deep_extend("force", config[k], v)
+    else
+      config[k] = v
+    end
+  end
   frecency.tune(config.algorithm)
 end
 

--- a/lua/arena/util.lua
+++ b/lua/arena/util.lua
@@ -3,6 +3,10 @@ local M = {}
 local function ancestors(path)
   local seen = {}
   local components = vim.fn.split(path, "/")
+  if #components <= 1 then
+    components = vim.fn.split(path, "\\\\")
+  end
+
   for i = 1, #components do
     local slice = { unpack(components, i) }
     table.insert(seen, vim.fn.join(slice, "/"))


### PR DESCRIPTION
On Window's PC's, even with vim.go.shellslash enabled, buffers are created with backslashes. In my example, I would see path's appear in arena as "C\\\\Users\\\\...", etc.. The proposed change adds an extra check for those backslashes in the case that we don't get any splits from checking for forward slashes.

Tested on both Windows and Arch-Linux. 

Also edited the setup function to handle some of the nested tables not getting passed in properly (in reference to issue #14). I was encountering the same problem which this change fixed for me. Would you be willing to test the changes out?