### PR TITLE
fix: apply configured keybinds on setup

### DIFF
--- a/lua/arena/init.lua
+++ b/lua/arena/init.lua
@@ -202,6 +202,7 @@ function M.setup(opts)
       config[k] = v
     end
   end
+  M.window.keymaps = vim.tbl_deep_extend("force", DEFAULT_KEYMAPS, config.keybinds)
   frecency.tune(config.algorithm)
 end
 


### PR DESCRIPTION
Keymaps were only applying on module loading, and not on setup, which made keymap configuration ineffective

This line fixes it